### PR TITLE
dateInformation field is removed and awardURI converted to tag attribute

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/index.html
+++ b/index.html
@@ -812,7 +812,6 @@
 				<div title="date" class="tag">
 					<input class="half-width input-field tag-value" type="text" placeholder="[DATE]" title="date" value="" />
 					<select class="half-width input-field tag-attribute" title="dateType"></select>
-					<input class="full-width input-field tag-value" type="text" placeholder="[DATE INFORMATION]" title="dateInformation" value="" />
 				</div>
 			</div>
 		</div>
@@ -1014,10 +1013,9 @@
 					</div>
 					<div title="awardNumber" class="tag">
 						<input class="half-width input-field tag-value" type="text" placeholder="[AWARD NUMBER]" title="awardNumber" value="" />
+						<input class="half-width input-field tag-attribute" type="text" placeholder="[AWARD URI]" title="awardURI" value="" />
 					</div>
-					<div title="awardURI" class="tag">
-						<input class="half-width input-field tag-value" type="text" placeholder="[AWARD URI]" title="awardURI" value="" />
-					</div>
+
 					<div title="awardTitle" class="tag">
 						<input class="full-width input-field tag-value" type="text" placeholder="[AWARD TITLE]" title="awardTitle" value="" />
 						<input class="language half-width input-field tag-attribute" type="text" maxlength="3" placeholder="[LANG]" title="xml:lang" value="" />


### PR DESCRIPTION
dateInformation field is removed because it is not used in the schema. 
awardURI converted to tag attribute as implemented in the schema.