### PR TITLE
Use textarea intead of input to enter description

### DIFF
--- a/index.html
+++ b/index.html
@@ -840,7 +840,7 @@
 			<button type="button" class="add group">+</button>
 			<div class="tag-group">
 				<div title="description" class="tag">
-					<input class="half-width input-field tag-value" type="text" placeholder="[DESCRIPTION]" title="description" value="" />
+					<textarea class="full-width input-field tag-value" type="text" placeholder="[DESCRIPTION]" title="description" value=""></textarea>
 					<input class="language half-width input-field tag-attribute" type="text" maxlength="3" placeholder="[LANG]" title="xml:lang" value="" />
 					<select class="half-width input-field tag-attribute" title="descriptionType"></select>
 				</div>


### PR DESCRIPTION
The description is multiline text input. Tag `textarea` accommodates this more efficiently than `input`.

Reference: https://stackoverflow.com/questions/5286663/wrapping-text-inside-input-type-text-element-html-css